### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,4 +1,6 @@
 name: gitleaks
+permissions:
+  contents: read
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SilverKnightKMA/clash-api-proxy/security/code-scanning/1](https://github.com/SilverKnightKMA/clash-api-proxy/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the steps in the workflow, the `contents: read` permission is sufficient, as the workflow only checks out the repository and runs the `gitleaks` action, which does not require write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
