### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ async function updateApiKey() {
         if (result.key) {
             ApiKey = result.key;
             // Do not log full API key; log masked value for traceability
-            console.log('API Key updated:', ApiKey ? ApiKey.slice(-4).padStart(ApiKey.length, '*') : '(no key)');
+            console.log('API Key updated successfully.');
             return true;
         }
         console.error('Failed to update API key: No key returned');


### PR DESCRIPTION
Potential fix for [https://github.com/SilverKnightKMA/clash-api-proxy/security/code-scanning/2](https://github.com/SilverKnightKMA/clash-api-proxy/security/code-scanning/2)

To fix the problem, avoid logging sensitive secrets in clear text. The best practice is to either eliminate the log line entirely or, if some logging is required for debugging/operational visibility, log only non-sensitive metadata (such as that the update succeeded, or a masked version of the key). In this specific case, on line 98 (`console.log('API Key updated:', ApiKey);`), the output should be changed to avoid printing the actual API key in clear text. You can either remove the key from the log message entirely, or, if you need some indication of the key's value (e.g., for debugging key rotation), log only a partial or masked version (e.g., the last 4 characters), which does not expose the full secret but can help trace which key is in use.

This requires updating the log statement in the `updateApiKey` function inside index.js. No new dependencies are required, and no additional method definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
